### PR TITLE
Add PR Secondary Role to staff page

### DIFF
--- a/lib/philomena_web/controllers/staff_controller.ex
+++ b/lib/philomena_web/controllers/staff_controller.ex
@@ -14,7 +14,8 @@ defmodule PhilomenaWeb.StaffController do
 
     categories = [
       "Administrators": Enum.filter(users, & &1.role == "admin"),
-      "Technical Team": Enum.filter(users, & &1.role != "admin" and &1.secondary_role not in [nil, ""]),
+      "Technical Team": Enum.filter(users, & &1.role != "admin" and &1.secondary_role in ["Site Developer", "System Administrator"]),
+      "Public Relations": Enum.filter(users, & &1.role != "admin" and &1.secondary_role == "Public Relations"),
       "Moderators": Enum.filter(users, & &1.role == "moderator" and &1.secondary_role in [nil, ""]),
       "Assistants": Enum.filter(users, & &1.role == "assistant" and &1.secondary_role in [nil, ""])
     ]


### PR DESCRIPTION
The secondary_role field is pretty entirely cosmetic and is not referenced anywhere other than in staff nametags (user_attribution_view.ex) and the staff directory page itself. Historically it's only been used for site developers, and thus if it was present at all it'd list anyone with it under "Technical Team", but this basically splits it up based on the value so that there can be a Technical Team, a PR Team, and any other team we may need in the future. 