### PR TITLE
Update to streamline Wilson score generation

### DIFF
--- a/lib/philomena/images/elasticsearch_index.ex
+++ b/lib/philomena/images/elasticsearch_index.ex
@@ -143,8 +143,7 @@ defmodule Philomena.Images.ElasticsearchIndex do
     }
   end
 
-  def wilson_score(%{upvotes_count: upvotes, downvotes_count: downvotes})
-      when upvotes > 0 do
+  def wilson_score(%{upvotes_count: upvotes, downvotes_count: downvotes}) when upvotes > 0 do
     # Population size
     n = (upvotes + downvotes) / 1
 

--- a/lib/philomena/images/elasticsearch_index.ex
+++ b/lib/philomena/images/elasticsearch_index.ex
@@ -144,7 +144,7 @@ defmodule Philomena.Images.ElasticsearchIndex do
   end
 
   def wilson_score(%{upvotes_count: upvotes, downvotes_count: downvotes})
-      when upvotes > 0 or downvotes > 0 do
+      when upvotes > 0 do
     # Population size
     n = (upvotes + downvotes) / 1
 


### PR DESCRIPTION
If an image's `upvotes` are 0, their Wilson score will be so minuscule as to be several (around 12) orders of magnitude before you see anything but zeros (assuming 0 `upvotes` and 1 `downvotes`). This will simply remove the calculation from such and make them fall to the default: 0