### PR TITLE
Fix for full image spoiling

### DIFF
--- a/lib/fast_textile/parser.ex
+++ b/lib/fast_textile/parser.ex
@@ -240,7 +240,7 @@ defmodule FastTextile.Parser do
   defp bracketed_image(parser, [{:bracketed_image, img} | r_tokens], _state) do
     src = escape(parser.image_transform.(img))
 
-    {:ok, [{:markup, "<span class=\"imagespoiler\"><img src=\""}, {:markup, src}, {:markup, "\"/></span>"}], r_tokens}
+    {:ok, [{:markup, "<span class=\"imgspoiler\"><img src=\""}, {:markup, src}, {:markup, "\"/></span>"}], r_tokens}
   end
   defp bracketed_image(_parser, _tokens, _state), do: {:error, "Expected a bracketed image"}
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [*] I understand all of the above

---

Sets the correct `class` for hiding images.
