### PR TITLE
Don't put UTF-8 in search URL

### DIFF
--- a/lib/philomena_web/controllers/tag_controller.ex
+++ b/lib/philomena_web/controllers/tag_controller.ex
@@ -140,7 +140,7 @@ defmodule PhilomenaWeb.TagController do
 
       %{aliased_tag: tag} ->
         conn
-        |> put_flash(:info, "This tag (`#{conn.assigns.tag.name}') has been aliased into the tag `#{tag.name}'.")
+        |> put_flash(:info, "This tag (\"#{conn.assigns.tag.name}\") has been aliased into the tag \"#{tag.name}\".")
         |> redirect(to: Routes.tag_path(conn, :show, tag))
     end
   end

--- a/lib/philomena_web/templates/layout/_header.html.slime
+++ b/lib/philomena_web/templates/layout/_header.html.slime
@@ -11,7 +11,7 @@ header.header
       a.header__link.hide-mobile href="/images/new" title="Upload"
         i.fa.fa-upload
 
-    = form_for @conn, Routes.search_path(@conn, :index), [method: "get", class: "header__search flex flex--no-wrap flex--centered"], fn f ->
+    = form_for @conn, Routes.search_path(@conn, :index), [method: "get", class: "header__search flex flex--no-wrap flex--centered", enforce_utf8: false], fn f ->
       input.input.header__input.header__input--search#q name="q" title="For terms all required, separate with ',' or 'AND'; also supports 'OR' for optional terms and '-' or 'NOT' for negation. Search with a blank query for more options or click the ? for syntax help." value=@conn.params["q"] placeholder="Search" autocapitalize="none"
 
       = if present?(@conn.params["sf"]) do


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

1. This removes the `_utf-8` parameter from the URL returned when a search is made from the search bar.
2. This also removes the TeX-style quoting that was visible in the message displayed when going to a tag page for an aliased tag, e.g. [spoiler:s06e10](https://derpibooru.org/tags/spoiler-colon-s06e10) → [applejack's "day" off](https://derpibooru.org/tags/applejack%2527s%2B%2522day%2522%2Boff).