### PR TITLE
Fix for distance

### DIFF
--- a/lib/philomena_web/controllers/api/json/search/reverse_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/reverse_controller.ex
@@ -10,6 +10,7 @@ defmodule PhilomenaWeb.Api.Json.Search.ReverseController do
   def create(conn, %{"image" => image_params}) do
     images =
       image_params
+      |> Map.put("distance", conn.params["distance"])
       |> ImageReverse.images()
       |> Enum.map(&ImageJson.as_json(conn, &1))
 
@@ -18,11 +19,21 @@ defmodule PhilomenaWeb.Api.Json.Search.ReverseController do
   end
 
   defp set_scraper_cache(conn, _opts) do
+
     params =
       conn.params
       |> Map.put("image", %{})
+      |> Map.put("distance", normalize_dist(conn.params))
       |> Map.put("scraper_cache", conn.params["url"])
 
     %{conn | params: params}
   end
+
+  defp normalize_dist(%{"distance" => distance}) do
+    "0" <> distance
+    |> Float.parse()
+    |> elem(0)
+    |> Float.to_string()
+  end
+  defp normalize_dist(_dist), do: "0.25"
 end

--- a/lib/philomena_web/controllers/api/json/search/reverse_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/reverse_controller.ex
@@ -19,7 +19,6 @@ defmodule PhilomenaWeb.Api.Json.Search.ReverseController do
   end
 
   defp set_scraper_cache(conn, _opts) do
-
     params =
       conn.params
       |> Map.put("image", %{})


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Fixes the `distance` to search not being passed through to `ImageReverse.images()`

`set_scraper_cache` passes the `distance` through into `params`
`create` normalizes and inserts the result into the params passed to `ImageReverse.images()`
`normalize_dist` checks if there is a `distance` set, adds a leading 0 to it (to account for values like `.5`, which would crash `Float.parse()`), and turns it back into a well-formatted string for `ImageReverse.images()`

This also changes the `image[distance]` value to just being `distance` instead.
