### PR TITLE
Fix to allow users to include deleted images again

### DIFF
--- a/lib/philomena_web/image_loader.ex
+++ b/lib/philomena_web/image_loader.ex
@@ -67,12 +67,12 @@ defmodule PhilomenaWeb.ImageLoader do
   end
 
   # Allow moderators to index hidden images
+  
+  defp maybe_show_deleted(filters, _show_hidden?, "1"),
+    do: filters
 
   defp maybe_show_deleted(filters, false, _param),
     do: [%{term: %{hidden_from_users: true}} | filters]
-
-  defp maybe_show_deleted(filters, true, "1"),
-    do: filters
 
   defp maybe_show_deleted(filters, true, "only"),
     do: [%{term: %{hidden_from_users: false}} | filters]


### PR DESCRIPTION
* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This used to be allowed in the old searching with the `deleted` param for all users.

This should correctly add back the ability (using the new `del` param) to specify `del=1` for any user/API search, but correctly block them from doing the more specialized "staff only" searching.
