### PR TITLE
Featured image hiding

### DIFF
--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -71,7 +71,7 @@ defmodule PhilomenaWeb.ActivityController do
     featured_image =
       Image
       |> join(:inner, [i], f in ImageFeature, on: [image_id: i.id])
-      |> filter_hidden(user, conn)
+      |> filter_hidden(user, conn.params["hidden"])
       |> order_by([i, f], desc: f.created_at)
       |> limit(1)
       |> preload([:tags])
@@ -118,13 +118,17 @@ defmodule PhilomenaWeb.ActivityController do
     )
   end
   
-  def filter_hidden(featured_image, nil, _conn) do
+  def filter_hidden(featured_image, nil, _hidden) do
     featured_image
   end
 
-  def filter_hidden(featured_image, user, conn) do
+  def filter_hidden(featured_image, _user, "1") do
+    featured_image
+  end
+
+  def filter_hidden(featured_image, user, _hidden) do
     featured_image 
       |> join(:left, [i, _f], h in ImageHide, on: h.image_id == i.id)
-      |> where([_i, _f, h], h.user_id != ^user.id or is_nil(h) or ^conn.params["hidden"] == 1)
+      |> where([_i, _f, h], h.user_id != ^user.id or is_nil(h))
   end
 end

--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -71,6 +71,7 @@ defmodule PhilomenaWeb.ActivityController do
     featured_image =
       Image
       |> join(:inner, [i], f in ImageFeature, on: [image_id: i.id])
+      |> filter_hidden(user, conn)
       |> order_by([i, f], desc: f.created_at)
       |> limit(1)
       |> preload([:tags])
@@ -115,5 +116,15 @@ defmodule PhilomenaWeb.ActivityController do
       interactions: interactions,
       layout_class: "layout--wide"
     )
+  end
+  
+  def filter_hidden(featured_image, nil, _conn) do
+    featured_image
+  end
+
+  def filter_hidden(featured_image, user, conn) do
+    featured_image 
+      |> join(:left, [i, _f], h in ImageHide, on: h.image_id == i.id)
+      |> where([_i, _f, h], h.user_id != ^user.id or is_nil(h) or ^conn.params["hidden"] == 1)
   end
 end

--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -127,8 +127,7 @@ defmodule PhilomenaWeb.ActivityController do
   end
 
   def filter_hidden(featured_image, user, _hidden) do
-    featured_image 
-      |> join(:left, [i, _f], h in ImageHide, on: h.image_id == i.id)
-      |> where([_i, _f, h], h.user_id != ^user.id or is_nil(h))
+    featured_image
+    |> where([i], fragment("NOT EXISTS(SELECT 1 FROM image_hides WHERE image_id = ? AND user_id = ?)", i.id, ^user.id))
   end
 end


### PR DESCRIPTION
* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This makes sure the Featured Image on the front page obeys user hiding.

It correctly allows non-logged-in users to see the featured image without hindrance.
It obeys `hidden=1` special option