### PR TITLE
Adds /api/v1/json/filters endpoints

### DIFF
--- a/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
@@ -1,0 +1,26 @@
+defmodule PhilomenaWeb.Api.Json.Filter.SystemFilterController do
+  use PhilomenaWeb, :controller
+
+  alias PhilomenaWeb.FilterJson
+  alias Philomena.Filters.Filter
+  alias Philomena.Repo
+  import Ecto.Query
+
+  def index(conn, _params) do
+    page = conn.assigns.pagination.page_number
+    page_size = conn.assigns.pagination.page_size
+
+    system_filters =
+      Filter
+      |> where(system: true)
+      |> order_by(asc: :id)
+      |> limit(^page_size)
+      |> offset((^page - 1) * ^page_size)
+      |> Repo.all()
+
+    json(conn, %{
+      filters: Enum.map(system_filters, &FilterJson.as_json/1),
+      page: page
+    })
+  end
+end

--- a/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
@@ -7,20 +7,14 @@ defmodule PhilomenaWeb.Api.Json.Filter.SystemFilterController do
   import Ecto.Query
 
   def index(conn, _params) do
-    page = conn.assigns.pagination.page_number
-    page_size = conn.assigns.pagination.page_size
-
     system_filters =
       Filter
       |> where(system: true)
       |> order_by(asc: :id)
-      |> limit(^page_size)
-      |> offset((^page - 1) * ^page_size)
-      |> Repo.all()
+      |> Repo.paginate(conn.assigns.scrivener)
 
     json(conn, %{
-      filters: Enum.map(system_filters, &FilterJson.as_json/1),
-      page: page
+      filters: Enum.map(system_filters, &FilterJson.as_json/1)
     })
   end
 end

--- a/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/system_filter_controller.ex
@@ -14,7 +14,8 @@ defmodule PhilomenaWeb.Api.Json.Filter.SystemFilterController do
       |> Repo.paginate(conn.assigns.scrivener)
 
     json(conn, %{
-      filters: Enum.map(system_filters, &FilterJson.as_json/1)
+      filters: Enum.map(system_filters, &FilterJson.as_json/1),
+      total: system_filters.total_entries
     })
   end
 end

--- a/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
@@ -8,8 +8,6 @@ defmodule PhilomenaWeb.Api.Json.Filter.UserFilterController do
 
   def index(conn, _params) do
     user = conn.assigns.current_user
-    page = conn.assigns.pagination.page_number
-    page_size = conn.assigns.pagination.page_size
 
     case user do
       nil ->
@@ -22,14 +20,10 @@ defmodule PhilomenaWeb.Api.Json.Filter.UserFilterController do
           Filter
           |> where(user_id: ^user.id)
           |> order_by(asc: :id)
-          |> preload(:user)
-          |> limit(^page_size)
-          |> offset((^page - 1) * ^page_size)
-          |> Repo.all()
+          |> Repo.paginate(conn.assigns.scrivener)
 
         json(conn, %{
-          filters: Enum.map(user_filters, &FilterJson.as_json/1),
-          page: page
+          filters: Enum.map(user_filters, &FilterJson.as_json/1)
         })
     end
   end

--- a/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
@@ -1,0 +1,36 @@
+defmodule PhilomenaWeb.Api.Json.Filter.UserFilterController do
+  use PhilomenaWeb, :controller
+
+  alias PhilomenaWeb.FilterJson
+  alias Philomena.Filters.Filter
+  alias Philomena.Repo
+  import Ecto.Query
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    page = conn.assigns.pagination.page_number
+    page_size = conn.assigns.pagination.page_size
+
+    case user do
+      nil ->
+        conn
+        |> put_status(:forbidden)
+        |> text("")
+
+      _ ->
+        user_filters =
+          Filter
+          |> where(user_id: ^user.id)
+          |> order_by(asc: :id)
+          |> preload(:user)
+          |> limit(^page_size)
+          |> offset((^page - 1) * ^page_size)
+          |> Repo.all()
+
+        json(conn, %{
+          filters: Enum.map(user_filters, &FilterJson.as_json/1),
+          page: page
+        })
+    end
+  end
+end

--- a/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter/user_filter_controller.ex
@@ -23,7 +23,8 @@ defmodule PhilomenaWeb.Api.Json.Filter.UserFilterController do
           |> Repo.paginate(conn.assigns.scrivener)
 
         json(conn, %{
-          filters: Enum.map(user_filters, &FilterJson.as_json/1)
+          filters: Enum.map(user_filters, &FilterJson.as_json/1),
+          total: user_filters.total_entries
         })
     end
   end

--- a/lib/philomena_web/controllers/api/json/filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter_controller.ex
@@ -25,4 +25,45 @@ defmodule PhilomenaWeb.Api.Json.FilterController do
         |> text("")
     end
   end
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    page = conn.assigns.pagination.page_number
+    page_size = conn.assigns.pagination.page_size
+
+    system_filters =
+      Filter
+      |> where(system: true)
+      |> Repo.all()
+
+    case user do
+      nil ->
+        json(conn, %{system_filters: Enum.map(system_filters, &FilterJson.as_json/1)})
+
+      _ ->
+        user_filters =
+          Filter
+          |> where(user_id: ^user.id)
+          |> order_by(asc: :id)
+          |> preload(:user)
+          |> limit(^page_size)
+          |> offset((^page - 1) * ^page_size)
+          |> Repo.all()
+
+        case page do
+          1 ->
+            json(conn, %{
+              system_filters: Enum.map(system_filters, &FilterJson.as_json/1),
+              user_filters: Enum.map(user_filters, &FilterJson.as_json/1),
+              page: page
+            })
+
+          _ ->
+            json(conn, %{
+              user_filters: Enum.map(user_filters, &FilterJson.as_json/1),
+              page: page
+            })
+        end
+    end
+  end
 end

--- a/lib/philomena_web/controllers/api/json/filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/filter_controller.ex
@@ -25,45 +25,4 @@ defmodule PhilomenaWeb.Api.Json.FilterController do
         |> text("")
     end
   end
-
-  def index(conn, _params) do
-    user = conn.assigns.current_user
-    page = conn.assigns.pagination.page_number
-    page_size = conn.assigns.pagination.page_size
-
-    system_filters =
-      Filter
-      |> where(system: true)
-      |> Repo.all()
-
-    case user do
-      nil ->
-        json(conn, %{system_filters: Enum.map(system_filters, &FilterJson.as_json/1)})
-
-      _ ->
-        user_filters =
-          Filter
-          |> where(user_id: ^user.id)
-          |> order_by(asc: :id)
-          |> preload(:user)
-          |> limit(^page_size)
-          |> offset((^page - 1) * ^page_size)
-          |> Repo.all()
-
-        case page do
-          1 ->
-            json(conn, %{
-              system_filters: Enum.map(system_filters, &FilterJson.as_json/1),
-              user_filters: Enum.map(user_filters, &FilterJson.as_json/1),
-              page: page
-            })
-
-          _ ->
-            json(conn, %{
-              user_filters: Enum.map(user_filters, &FilterJson.as_json/1),
-              page: page
-            })
-        end
-    end
-  end
 end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -119,7 +119,7 @@ defmodule PhilomenaWeb.Router do
     resources "/comments", CommentController, only: [:show]
     resources "/posts", PostController, only: [:show]
     resources "/profiles", ProfileController, only: [:show]
-    resources "/filters", FilterController, only: [:show]
+    resources "/filters", FilterController, only: [:show, :index]
 
     resources "/forums", ForumController, only: [:show, :index] do
       resources "/topics", Forum.TopicController, only: [:show, :index] do

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -119,7 +119,13 @@ defmodule PhilomenaWeb.Router do
     resources "/comments", CommentController, only: [:show]
     resources "/posts", PostController, only: [:show]
     resources "/profiles", ProfileController, only: [:show]
-    resources "/filters", FilterController, only: [:show, :index]
+
+    scope "/filters", Filter, as: :filter do
+      resources "/user", UserFilterController, only: [:index]
+      resources "/system", SystemFilterController, only: [:index]
+    end
+
+    resources "/filters", FilterController, only: [:show]
 
     resources "/forums", ForumController, only: [:show, :index] do
       resources "/topics", Forum.TopicController, only: [:show, :index] do


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This adds a `/api/v1/json/filters` endpoint that will return `system` filters or `system` filters and `user` filters if an API key is given. Will also paginate through `user` filters using a `page` parameter.
