### PR TITLE
Adding text editing bars to report and new topic

### DIFF
--- a/lib/philomena_web/templates/report/new.html.slime
+++ b/lib/philomena_web/templates/report/new.html.slime
@@ -40,8 +40,25 @@ p
   = form_for @changeset, @action, fn f ->
     .field
       = select f, :category, report_categories(), class: "input"
-    .field
-      = textarea f, :reason, class: "input input--wide", placeholder: "Provide anything else we should know here."
+    .block
+      .block__header.block__header--js-tabbed
+        a.selected href="#" data-click-tab="write"
+          i.fas.fa-edit>
+          ' Edit
+
+        a href="#" data-click-tab="preview"
+          i.fa.fa-eye>
+          ' Preview
+
+      .block__tab.communication-edit__tab.selected data-tab="write"
+        = render PhilomenaWeb.TextileView, "_help.html", conn: @conn
+        = render PhilomenaWeb.TextileView, "_toolbar.html", conn: @conn
+
+        .field
+          = textarea f, :reason, class: "input input--wide input--text js-preview-input js-toolbar-input", placeholder: "Provide anything else we should know here."
+
+      .block__tab.communication-edit__tab.hidden data-tab="preview"
+        ' [Loading preview...]
 
     = if !@conn.assigns.current_user do
       .field

--- a/lib/philomena_web/templates/topic/new.html.slime
+++ b/lib/philomena_web/templates/topic/new.html.slime
@@ -21,6 +21,8 @@
 
       = inputs_for f, :posts, fn fp ->
         .field
+          = render PhilomenaWeb.TextileView, "_help.html", conn: @conn
+          = render PhilomenaWeb.TextileView, "_toolbar.html", conn: @conn
           = textarea fp, :body, class: "input input--wide input--text js-preview-input js-toolbar-input", placeholder: "Please read the site rules before posting and use [spoiler][/spoiler] for NSFW stuff in SFW forums.", required: true
           = error_tag fp, :body
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This adds text editing bars to `New Topic` page and adds text editing bars and previewing to `New Report` pages.
