### PR TITLE
Add timestamps to the API's comment view

### DIFF
--- a/lib/philomena_web/views/api/json/comment_view.ex
+++ b/lib/philomena_web/views/api/json/comment_view.ex
@@ -23,7 +23,9 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
       image_id: comment.image_id,
       user_id: nil,
       author: nil,
-      body: nil
+      body: nil,
+      posted_at: nil,
+      updated_at: nil
     }
   end
 
@@ -37,7 +39,9 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
           do: UserAttributionView.anonymous_name(comment),
           else: comment.user.name
         ),
-      body: nil
+      body: nil,
+      posted_at: comment.created_at,
+      updated_at: comment.updated_at
     }
   end
 
@@ -51,7 +55,9 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
           do: UserAttributionView.anonymous_name(comment),
           else: comment.user.name
         ),
-      body: comment.body
+      body: comment.body,
+      posted_at: comment.created_at,
+      updated_at: comment.updated_at
     }
   end
 end

--- a/lib/philomena_web/views/api/json/comment_view.ex
+++ b/lib/philomena_web/views/api/json/comment_view.ex
@@ -24,7 +24,7 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
       user_id: nil,
       author: nil,
       body: nil,
-      posted_at: nil,
+      created_at: nil,
       updated_at: nil
     }
   end
@@ -40,7 +40,7 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
           else: comment.user.name
         ),
       body: nil,
-      posted_at: comment.created_at,
+      created_at: comment.created_at,
       updated_at: comment.updated_at
     }
   end
@@ -56,7 +56,7 @@ defmodule PhilomenaWeb.Api.Json.CommentView do
           else: comment.user.name
         ),
       body: comment.body,
-      posted_at: comment.created_at,
+      created_at: comment.created_at,
       updated_at: comment.updated_at
     }
   end


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Fixes #66.

Getting the dev environment set up in Windows was an interesting challenge. Thank goodness for the VS Code Remoting extension. Never did get debugging working though.

All the comment views now include two new fields:

- `posted_at`, the database's `created_at` field, and
- `updated_at`, the field of the same name in the database

They're `nil`ed out on deleted images, but included in deleted comments. I wasn't sure how to hide a comment from users though, so I wasn't able to test that code path.