### PR TITLE
image upload mime validation - shows you what it thinks the mime type is

### DIFF
--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -155,7 +155,8 @@ defmodule Philomena.Images.Image do
     |> validate_length(:image_name, max: 255, count: :bytes)
     |> validate_inclusion(
       :image_mime_type,
-      ~W(image/gif image/jpeg image/png image/svg+xml video/webm)
+      ~W(image/gif image/jpeg image/png image/svg+xml video/webm),
+      message: "(#{attrs["image_mime_type"]}) is invalid"
     )
     |> unsafe_validate_unique([:image_orig_sha512_hash], Repo)
   end

--- a/lib/philomena/mime.ex
+++ b/lib/philomena/mime.ex
@@ -33,5 +33,5 @@ defmodule Philomena.Mime do
       when mime in ~W(image/gif image/jpeg image/png image/svg+xml video/webm),
       do: {:ok, mime}
 
-  def true_mime(_mime), do: :error
+  def true_mime(mime), do: {:unsupported_mime, mime}
 end

--- a/lib/philomena/uploader.ex
+++ b/lib/philomena/uploader.ex
@@ -43,6 +43,10 @@ defmodule Philomena.Uploader do
 
       changeset_fn.(model_or_changeset, attributes)
     else
+      {:unsupported_mime, mime} ->
+        attributes = prefix_attributes(%{"mime_type" => mime}, field_name)
+        changeset_fn.(model_or_changeset, attributes)
+
       _error ->
         changeset_fn.(model_or_changeset, %{})
     end


### PR DESCRIPTION
Helps resolve cases like #78 earlier
Requesting testing for uploading both valid and invalid image types

![](https://cdn.discordapp.com/attachments/662895347911098368/696932140901859328/Screenshot_from_2020-04-06_23-59-20.png)
