### PR TITLE
Properly handle failed captchas after XHR post

### DIFF
--- a/assets/js/ujs.js
+++ b/assets/js/ujs.js
@@ -2,7 +2,8 @@ import { $$, makeEl, findFirstTextNode } from './utils/dom';
 import { fire, delegate, leftClick } from './utils/events';
 
 const headers = () => ({
-  'x-csrf-token': window.booru.csrfToken
+  'x-csrf-token': window.booru.csrfToken,
+  'x-requested-with': 'XMLHttpRequest'
 });
 
 function confirm(event, target) {
@@ -56,9 +57,13 @@ function formRemote(event, target) {
     method: (target.dataset.method || target.method || 'POST').toUpperCase(),
     headers: headers(),
     body: new FormData(target)
-  }).then(response =>
+  }).then(response => {
+    if (response && response.status == 300) {
+      window.location.reload(true);
+      return;
+    }
     fire(target, 'fetchcomplete', response)
-  );
+  });
 }
 
 function formReset(event, target) {

--- a/lib/philomena_web/plugs/captcha_plug.ex
+++ b/lib/philomena_web/plugs/captcha_plug.ex
@@ -1,7 +1,7 @@
 defmodule PhilomenaWeb.CaptchaPlug do
   alias Philomena.Captcha
-  alias Phoenix.Controller
-  alias Plug.Conn
+  import Plug.Conn
+  import Phoenix.Controller
 
   def init([]), do: false
 
@@ -19,31 +19,29 @@ defmodule PhilomenaWeb.CaptchaPlug do
 
       false ->
         conn
-        |> Controller.put_flash(
+        |> put_flash(
           :error,
           "There was an error verifying you're not a robot. Please try again."
         )
-        |> do_failure_response()
-        |> Conn.halt()
+        |> do_failure_response(ajax?(conn))
+        |> halt()
     end
   end
 
   defp maybe_check_captcha(conn, _user), do: conn
 
-  defp do_failure_response(conn) do
-    case ajax?(conn) do
-      true ->
-        conn
-        |> Conn.put_status(:multiple_choices)
-        |> Controller.text("")
-      false ->
-        conn
-        |> Controller.redirect(external: conn.assigns.referrer)
-    end
+  defp do_failure_response(conn, true) do
+    conn
+    |> put_status(:multiple_choices)
+    |> text("")
+  end
+
+  defp do_failure_response(conn, _false) do
+    redirect(conn, external: conn.assigns.referrer)
   end
 
   def ajax?(conn) do
-    case Conn.get_req_header(conn, "x-requested-with") do
+    case get_req_header(conn, "x-requested-with") do
       [value] -> String.downcase(value) == "xmlhttprequest"
       _ -> false
     end

--- a/lib/philomena_web/plugs/captcha_plug.ex
+++ b/lib/philomena_web/plugs/captcha_plug.ex
@@ -23,10 +23,29 @@ defmodule PhilomenaWeb.CaptchaPlug do
           :error,
           "There was an error verifying you're not a robot. Please try again."
         )
-        |> Controller.redirect(external: conn.assigns.referrer)
+        |> do_failure_response()
         |> Conn.halt()
     end
   end
 
   defp maybe_check_captcha(conn, _user), do: conn
+
+  defp do_failure_response(conn) do
+    case ajax?(conn) do
+      true ->
+        conn
+        |> Conn.put_status(:multiple_choices)
+        |> Controller.text("")
+      false ->
+        conn
+        |> Controller.redirect(external: conn.assigns.referrer)
+    end
+  end
+
+  def ajax?(conn) do
+    case Conn.get_req_header(conn, "x-requested-with") do
+      [value] -> String.downcase(value) == "xmlhttprequest"
+      _ -> false
+    end
+  end
 end


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [ x] I understand all of the above

---

Only redirect user if failed captcha was submitted via a form post. For XHR posts, return a 300 and let the client JS reload the page to show the flash message
