### PR TITLE
Persist checked state of art categories across commission pages

### DIFF
--- a/lib/philomena_web/templates/commission/_directory_sidebar.html.slime
+++ b/lib/philomena_web/templates/commission/_directory_sidebar.html.slime
@@ -6,8 +6,9 @@
       .field = label f, :categories, "Art Categories:"
 
       = for {name, value} <- categories() do
+        - checked = @conn.params["commission"]["category"] && Atom.to_string(name) in @conn.params["commission"]["category"]
         .field
-          => checkbox f, value, checked_value: name, name: "commission[category][]", class: "checkbox spacing-right", hidden_input: false
+          => checkbox f, value, checked_value: name, checked: checked, name: "commission[category][]", class: "checkbox spacing-right", hidden_input: false
           => label f, value, name
 
       br

--- a/lib/philomena_web/templates/profile/commission/_form.html.slime
+++ b/lib/philomena_web/templates/profile/commission/_form.html.slime
@@ -23,7 +23,7 @@
   .field
     => label f, :categories, "Art Categories:"
     br
-    = collection_checkboxes f, :categories, categories(), wrapper: &Phoenix.HTML.Tag.content_tag(:span, &1, class: "commission__category")
+    = collection_checkboxes f, :categories, categories(), selected: f.data.categories, input_opts: [ class: 'checkbox spacing-right' ], wrapper: &Phoenix.HTML.Tag.content_tag(:span, &1, class: "commission__category")
     = error_tag f, :categories
   .field
     => label f, :sheet_image_id, "Image ID of your commissions sheet (optional but recommended):"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

The checked state of checkboxes for art categories across the commission-related pages was not persisted in the DOM between page loads. This PR aims to fix this issue in the search sidebar and listing editing form.