### PR TITLE
Disable image scraper fetch when there is no text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ npm-debug.log
 
 # Mnesia
 /Mnesia*
+
+# Intellij IDEA
+.idea

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -67,6 +67,7 @@ function setupImageUpload() {
     // Clear any currently cached data, because the file field
     // has higher priority than the scraper:
     remoteUrl.value = '';
+    disableFetch();
     hideError();
   });
 
@@ -100,6 +101,15 @@ function setupImageUpload() {
 
       enableFetch();
     }).catch(showError);
+  });
+
+  // Enable/disable the fetch button based on content in the image scraper. Fetching with no URL makes no sense.
+  remoteUrl.addEventListener('input', () => {
+    if(remoteUrl.value.length > 0) {
+      enableFetch();
+    } else {
+      disableFetch();
+    }
   });
 }
 

--- a/lib/philomena_web/templates/avatar/edit.html.slime
+++ b/lib/philomena_web/templates/avatar/edit.html.slime
@@ -29,7 +29,7 @@
 
           .field.field--inline
             = url_input f, :scraper_url, class: "input input--wide js-scraper", placeholder: "Link a deviantART page, a Tumblr post, or the image directly"
-            button.button.button--separate-left#js-scraper-preview type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch"
+            button.button.button--separate-left#js-scraper-preview(type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch" disabled)
               ' Fetch
 
           .field-error-js.hidden.js-scraper

--- a/lib/philomena_web/templates/image/new.html.slime
+++ b/lib/philomena_web/templates/image/new.html.slime
@@ -39,7 +39,7 @@
 
     .field.field--inline
       = url_input f, :scraper_url, class: "input input--wide js-scraper", placeholder: "Link a deviantART page, a Tumblr post, or the image directly"
-      button.button.button--separate-left#js-scraper-preview type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch"
+      button.button.button--separate-left#js-scraper-preview(type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch" disabled)
         ' Fetch
 
     .field-error-js.hidden.js-scraper

--- a/lib/philomena_web/templates/search/reverse/index.html.slime
+++ b/lib/philomena_web/templates/search/reverse/index.html.slime
@@ -16,7 +16,7 @@ h1 Reverse Search
 
     .field.field--inline
       = url_input f, :url, name: "url", class: "input input--wide js-scraper", placeholder: "Link a deviantART page, a Tumblr post, or the image directly"
-      button.button.button--separate-left#js-scraper-preview type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch"
+      button.button.button--separate-left#js-scraper-preview(type="button" title="Fetch the image at the specified URL" data-disable-with="Fetch" disabled)
         ' Fetch
 
     .field-error-js.hidden.js-scraper


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [✓] I understand all of the above

---

  *Modified html so fetch is disabled on pageload. Javascript enables it after the user has entered some text. Re-disables it if the text goes to zero, or the image upload button has been used.
