### PR TITLE
Api create image

### DIFF
--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -2,9 +2,17 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
   use PhilomenaWeb, :controller
 
   alias Philomena.Images.Image
+  alias Philomena.Images
   alias Philomena.Interactions
   alias Philomena.Repo
+  alias Philomena.Tags
+  alias Philomena.UserStatistics
   import Ecto.Query
+
+  import EctoNetwork.INET
+
+  plug :set_scraper_cache
+  plug PhilomenaWeb.ScraperPlug, params_key: "image", params_name: "image"
 
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
@@ -25,6 +33,76 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
         interactions = Interactions.user_interactions([image], user)
 
         render(conn, "show.json", image: image, interactions: interactions)
+    end
+  end
+
+  def create(conn, %{"image" => image_params} = params) do
+    user = conn.assigns.current_user
+
+    params =
+      params
+      |> Map.put("scraper_url", Map.get(params, "url"))
+      |> Map.put("anonymous", Map.get(params, "anonymous", false))
+      |> Map.put("source_url", Map.get(params, "source_url", ""))
+      |> Map.put("description", Map.get(params, "description", ""))
+      |> Map.merge(image_params)
+
+    case user do
+      nil ->
+        conn
+        |> put_status(:unauthorized)
+        |> text("")
+
+      _ ->
+        attributes = %{
+          user: user,
+          ip: decode_ip(conn.remote_ip),
+          fingerprint: "c415049"
+        }
+
+        case Images.create_image(attributes, params) do
+          {:ok, %{image: image}} ->
+            spawn(fn ->
+              Images.repair_image(image)
+            end)
+
+            # ImageProcessor.cast(image.id)
+            Images.reindex_image(image)
+            Tags.reindex_tags(image.added_tags)
+            UserStatistics.inc_stat(user, :uploads)
+
+            interactions = Interactions.user_interactions([image], user)
+
+            conn
+            |> put_view(PhilomenaWeb.Api.Json.ImageView)
+            |> render("show.json", image: image, interactions: interactions)
+
+          {:error, :image, changeset, _} ->
+            IO.inspect(changeset, label: "Error")
+
+            conn
+            |> put_status(:bad_request)
+            |> render("error.json", changeset: changeset)
+        end
+    end
+  end
+
+  defp set_scraper_cache(conn, _opts) do
+    params =
+      conn.params
+      |> Map.put("image", %{})
+      |> Map.put("scraper_cache", conn.params["url"])
+
+    %{conn | params: params}
+  end
+
+  defp decode_ip(remote_ip) do
+    case EctoNetwork.INET.cast(remote_ip) do
+      {:ok, cast_ip} ->
+        cast_ip
+
+      _ ->
+        nil
     end
   end
 end

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -43,7 +43,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
 
     attributes =
       conn.assigns.attributes
-      |> List.keyreplace(:fingerprint, 0, {:fingerprint, "API"})
+      |> Keyword.put(:fingerprint, "API")
 
     case Images.create_image(attributes, image_params) do
       {:ok, %{image: image}} ->

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -53,9 +53,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
         Tags.reindex_tags(image.added_tags)
         UserStatistics.inc_stat(user, :uploads)
 
-        conn
-        |> put_view(PhilomenaWeb.Api.Json.ImageView)
-        |> render("show.json", image: image, interactions: [])
+        render(conn, "show.json", image: image, interactions: [])
 
       {:error, :image, changeset, _} ->
         conn

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -40,10 +40,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
 
   def create(conn, %{"image" => image_params}) do
     user = conn.assigns.current_user
-
-    attributes =
-      conn.assigns.attributes
-      |> Keyword.put(:fingerprint, "API")
+    attributes = conn.assigns.attributes
 
     case Images.create_image(attributes, image_params) do
       {:ok, %{image: image}} ->

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -78,8 +78,6 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
             |> render("show.json", image: image, interactions: interactions)
 
           {:error, :image, changeset, _} ->
-            IO.inspect(changeset, label: "Error")
-
             conn
             |> put_status(:bad_request)
             |> render("error.json", changeset: changeset)

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -38,16 +38,8 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
     end
   end
 
-  def create(conn, %{"image" => image_params} = params) do
+  def create(conn, %{"image" => image_params}) do
     user = conn.assigns.current_user
-
-    image_params =
-      image_params
-      |> Map.put("scraper_url", Map.get(params, "url"))
-      |> Map.put("anonymous", Map.get(params, "anonymous", false))
-      |> Map.put("source_url", Map.get(params, "source_url", ""))
-      |> Map.put("description", Map.get(params, "description", ""))
-      |> Map.put("tag_input", Map.get(params, "tags", ""))
 
     attributes =
       conn.assigns.attributes
@@ -78,7 +70,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
   defp set_scraper_cache(conn, _opts) do
     params =
       conn.params
-      |> Map.put("image", %{})
+      |> Map.put_new("image", %{})
       |> Map.put("scraper_cache", conn.params["url"])
 
     %{conn | params: params}

--- a/lib/philomena_web/plugs/api_require_authorization_plug.ex
+++ b/lib/philomena_web/plugs/api_require_authorization_plug.ex
@@ -1,0 +1,45 @@
+defmodule PhilomenaWeb.ApiRequireAuthorizationPlug do
+  @moduledoc """
+  This plug will force a 401 Unauthorized if no/invalid
+  API key provided.
+
+  ## Example
+
+      plug PhilomenaWeb.ApiRequireAuthorizationPlug
+  """
+  alias Phoenix.Controller
+  alias Plug.Conn
+  alias Philomena.Bans
+
+  @doc false
+  @spec init(any()) :: any()
+  def init(opts), do: opts
+
+  @doc false
+  @spec call(Conn.t(), any()) :: Conn.t()
+  def call(conn, _opts) do
+    user = conn.assigns.current_user
+
+    conn
+    |> maybe_unauthorized(user)
+    |> maybe_forbidden(Bans.exists_for?(user, conn.remote_ip, "NOTAPI"))
+  end
+
+  defp maybe_unauthorized(conn, nil) do
+    conn
+    |> Conn.put_status(:unauthorized)
+    |> Controller.text("")
+    |> Conn.halt()
+  end
+
+  defp maybe_unauthorized(conn, _user), do: conn
+
+  defp maybe_forbidden(conn, nil), do: conn
+
+  defp maybe_forbidden(conn, _current_ban) do
+    conn
+    |> Conn.put_status(:forbidden)
+    |> Controller.text("")
+    |> Conn.halt()
+  end
+end

--- a/lib/philomena_web/plugs/api_require_authorization_plug.ex
+++ b/lib/philomena_web/plugs/api_require_authorization_plug.ex
@@ -1,7 +1,7 @@
 defmodule PhilomenaWeb.ApiRequireAuthorizationPlug do
   @moduledoc """
   This plug will force a 401 Unauthorized if no/invalid
-  API key provided.
+  API key provided and a 403 Forbidden if user is banned.
 
   ## Example
 

--- a/lib/philomena_web/plugs/user_attribution_plug.ex
+++ b/lib/philomena_web/plugs/user_attribution_plug.ex
@@ -23,7 +23,7 @@ defmodule PhilomenaWeb.UserAttributionPlug do
 
     attributes = [
       ip: remote_ip,
-      fingerprint: fingerprint(conn, List.head(conn.path_info)),
+      fingerprint: fingerprint(conn, conn.path_info),
       referrer: conn.assigns.referrer,
       user: user,
       user_agent: user_agent(conn)
@@ -40,12 +40,11 @@ defmodule PhilomenaWeb.UserAttributionPlug do
     end
   end
 
-  defp fingerprint(conn, "api") do
+  defp fingerprint(conn, ["api" | _]) do
     "a#{:erlang.crc32(user_agent(conn))}"
   end
 
-  defp fingerprint(conn, _format) do
+  defp fingerprint(conn, _) do
     conn.cookies["_ses"]
   end
-
 end

--- a/lib/philomena_web/plugs/user_attribution_plug.ex
+++ b/lib/philomena_web/plugs/user_attribution_plug.ex
@@ -23,7 +23,7 @@ defmodule PhilomenaWeb.UserAttributionPlug do
 
     attributes = [
       ip: remote_ip,
-      fingerprint: conn.cookies["_ses"],
+      fingerprint: fingerprint(conn, List.head(conn.path_info)),
       referrer: conn.assigns.referrer,
       user: user,
       user_agent: user_agent(conn)
@@ -39,4 +39,13 @@ defmodule PhilomenaWeb.UserAttributionPlug do
       _ -> nil
     end
   end
+
+  defp fingerprint(conn, "api") do
+    "a#{:erlang.crc32(user_agent(conn))}"
+  end
+
+  defp fingerprint(conn, _format) do
+    conn.cookies["_ses"]
+  end
+
 end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -110,7 +110,7 @@ defmodule PhilomenaWeb.Router do
       resources "/featured", FeaturedController, only: [:show], singleton: true
     end
 
-    resources "/images", ImageController, only: [:show]
+    resources "/images", ImageController, only: [:show, :create]
 
     scope "/search", Search, as: :search do
       resources "/reverse", ReverseController, only: [:create]

--- a/lib/philomena_web/views/api/json/image_view.ex
+++ b/lib/philomena_web/views/api/json/image_view.ex
@@ -2,8 +2,6 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
   use PhilomenaWeb, :view
   alias PhilomenaWeb.ImageView
 
-  # import Ecto.Changeset
-
   def render("index.json", %{images: images, interactions: interactions, total: total} = assigns) do
     %{
       images: render_many(images, PhilomenaWeb.Api.Json.ImageView, "image.json", assigns),

--- a/lib/philomena_web/views/api/json/image_view.ex
+++ b/lib/philomena_web/views/api/json/image_view.ex
@@ -2,6 +2,8 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
   use PhilomenaWeb, :view
   alias PhilomenaWeb.ImageView
 
+  # import Ecto.Changeset
+
   def render("index.json", %{images: images, interactions: interactions, total: total} = assigns) do
     %{
       images: render_many(images, PhilomenaWeb.Api.Json.ImageView, "image.json", assigns),
@@ -80,6 +82,12 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
       deletion_reason: nil,
       duplicate_of: nil,
       hidden_from_users: false
+    }
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    %{
+      errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
     }
   end
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Adds the `POST` method to `/api/v1/json/images` to allow for API-based creation of images.

Requires API key be used. Logs IP address. Sets fingerprint to `c415049`.

Same tag requirements as site uploading.
Description and source are optional.

Will return newly created image and a `200` on success.
Will return nothing and `401` if API key missing or invalid.
Will return nothing and `403` if IP is banned or API key exists and user is banned (as per normal banning rules, excluding `fingerprint`).
Will return errors and a `400` if image could not be created.