### PR TITLE
Add Philomena Contrib Sec Role, Staff Page Visibility Toggle

### DIFF
--- a/lib/philomena_web/controllers/staff_controller.ex
+++ b/lib/philomena_web/controllers/staff_controller.ex
@@ -13,7 +13,7 @@ defmodule PhilomenaWeb.StaffController do
       |> Repo.all()
 
     categories = [
-      Administrators: Enum.filter(users, &(&1.role == "admin")),
+      Administrators: Enum.filter(users, &(&1.role == "admin" and &1.hide_default_role == false)),
       "Technical Team":
         Enum.filter(
           users,
@@ -22,8 +22,8 @@ defmodule PhilomenaWeb.StaffController do
       "Public Relations":
         Enum.filter(users, &(&1.role != "admin" and &1.secondary_role == "Public Relations")),
       Moderators:
-        Enum.filter(users, &(&1.role == "moderator" and &1.secondary_role in [nil, ""])),
-      Assistants: Enum.filter(users, &(&1.role == "assistant" and &1.secondary_role in [nil, ""]))
+        Enum.filter(users, &(&1.role == "moderator" and &1.secondary_role in [nil, ""] and &1.hide_default_role == false)),
+      Assistants: Enum.filter(users, &(&1.role == "assistant" and &1.secondary_role in [nil, ""] and &1.hide_default_role == false))
     ]
 
     render(conn, "index.html", title: "Site Staff", categories: categories)

--- a/lib/philomena_web/templates/admin/user/_form.html.slime
+++ b/lib/philomena_web/templates/admin/user/_form.html.slime
@@ -17,7 +17,7 @@
       .table-list__label__input = select f, :role, ["user", "assistant", "moderator", "admin"], class: "input"
     label.table-list__label
       .table-list__label__text Secondary banner:
-      .table-list__label__input = select f, :secondary_role, [[key: "-", value: ""], "Site Developer", "System Administrator", "Public Relations"], class: "input"
+      .table-list__label__input = select f, :secondary_role, [[key: "-", value: ""], "Site Developer", "System Administrator", "Philomena Contributor", "Public Relations"], class: "input"
     label.table-list__label
       .table-list__label__text Hide staff banner:
       .table-list__label__input = checkbox f, :hide_default_role, class: "checkbox"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3
* I am definitely wearing pants

- [x] I understand all of the above

---

1) Adds "Philomena Contributor" as a selectable secondary role so that this doesn't have to be manually hacked in via psql

2) Toggles visibility on the staff list based on the hide_default_role flags - this is so that if a staff member is on break from staff duties but still need the role set (for accessing staff forums and the like), they won't appear on the staff page.