### PR TITLE
Hide staff tag change banner for unavailable staff, and show unavailable staff on staff page.

### DIFF
--- a/assets/css/views/_profiles.scss
+++ b/assets/css/views/_profiles.scss
@@ -137,3 +137,11 @@ td.table--stats__sparkline {
   width: 125px;
   height: 125px;
 }
+
+.avatar-disabled {
+  opacity: 0.4;
+}
+
+.staff-title-muted {
+  color: #777;
+}

--- a/lib/philomena_web/controllers/staff_controller.ex
+++ b/lib/philomena_web/controllers/staff_controller.ex
@@ -13,7 +13,7 @@ defmodule PhilomenaWeb.StaffController do
       |> Repo.all()
 
     categories = [
-      Administrators: Enum.filter(users, &(&1.role == "admin" and &1.hide_default_role == false)),
+      Administrators: Enum.filter(users, &(&1.role == "admin")),
       "Technical Team":
         Enum.filter(
           users,
@@ -24,14 +24,12 @@ defmodule PhilomenaWeb.StaffController do
       Moderators:
         Enum.filter(
           users,
-          &(&1.role == "moderator" and &1.secondary_role in [nil, ""] and
-              &1.hide_default_role == false)
+          &(&1.role == "moderator" and &1.secondary_role in [nil, ""])
         ),
       Assistants:
         Enum.filter(
           users,
-          &(&1.role == "assistant" and &1.secondary_role in [nil, ""] and
-              &1.hide_default_role == false)
+          &(&1.role == "assistant" and &1.secondary_role in [nil, ""])
         )
     ]
 

--- a/lib/philomena_web/templates/staff/index.html.slime
+++ b/lib/philomena_web/templates/staff/index.html.slime
@@ -6,7 +6,14 @@ h1 Staff
       h4 = header
 
       = for user <- users do
-        a.profile-block href=Routes.profile_path(@conn, :show, user)
-          = render PhilomenaWeb.UserAttributionView, "_user_avatar.html", object: %{user: user}, class: "avatar--125px"
-          b
-            => user.name
+      	= if user.hide_default_role do
+      	  .profile-block
+            = render PhilomenaWeb.UserAttributionView, "_user_avatar.html", object: %{user: user}, class: "avatar--125px avatar-disabled"
+            b.staff-title-muted
+              => user.name
+              | (Unavailable)
+      	- else
+          a.profile-block href=Routes.profile_path(@conn, :show, user)
+            = render PhilomenaWeb.UserAttributionView, "_user_avatar.html", object: %{user: user}, class: "avatar--125px"
+            b
+              => user.name

--- a/lib/philomena_web/views/tag_change_view.ex
+++ b/lib/philomena_web/views/tag_change_view.ex
@@ -4,7 +4,7 @@ defmodule PhilomenaWeb.TagChangeView do
   def staff?(tag_change),
     do:
       not is_nil(tag_change.user) and not Philomena.Attribution.anonymous?(tag_change) and
-        tag_change.user.role != "user"
+        tag_change.user.role != "user" and not tag_change.user.hide_default_role
 
   def user_column_class(tag_change) do
     case staff?(tag_change) do


### PR DESCRIPTION
As discussed on Discord, here's what it looks like.

![image](https://user-images.githubusercontent.com/1939757/87253219-eb354080-c468-11ea-8853-28c55be9683c.png)
